### PR TITLE
Make c wrapper

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
@@ -1,3 +1,6 @@
+
+set -euo pipefail
+
 # Assert that FILE exists and is executable
 #
 # assertExecutable FILE

--- a/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
@@ -35,7 +35,7 @@ assertExecutable() {
 makeWrapper() {
     assertExecutable "$1"
     makeDocumentedCWrapper "$1" "${@:3}" | \
-      cc \
+      @CC@ \
         -Wall -Werror -Wpedantic \
         -Os \
         -x c \

--- a/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
@@ -31,7 +31,12 @@ assertExecutable() {
 # use the `strings` command or open the binary file in a text editor.
 makeWrapper() {
     assertExecutable "$1"
-    makeDocumentedCWrapper "$1" "${@:3}" | cc -Os -x c -o "$2" -
+    makeDocumentedCWrapper "$1" "${@:3}" | \
+      cc \
+        -Wall -Werror -Wpedantic \
+        -Os \
+        -x c \
+        -o "$2" -
 }
 
 # Syntax: wrapProgram <PROGRAM> <MAKE-WRAPPER FLAGS...>

--- a/pkgs/test/make-binary-wrapper/default.nix
+++ b/pkgs/test/make-binary-wrapper/default.nix
@@ -3,7 +3,7 @@
 let
   env = { nativeBuildInputs = [ makeBinaryWrapper ]; };
   envCheck = runCommand "envcheck" env ''
-    ${gcc}/bin/cc -o $out ${./envcheck.c}
+    ${gcc}/bin/cc -Wall -Werror -Wpedantic -o $out ${./envcheck.c}
   '';
   makeGoldenTest = testname: runCommand "test-wrapper_${testname}" env ''
     mkdir -p /tmp/foo

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -606,11 +606,13 @@ in
   makeWrapper = makeSetupHook { deps = [ dieHook ]; substitutions = { shell = targetPackages.runtimeShell; }; }
                               ../build-support/setup-hooks/make-wrapper.sh;
 
-  makeBinaryWrapper = makeSetupHook {
-    deps = [ dieHook ];
-  } (runCommand "make-binary-wrapper.sh" {} ''
-      substitute ${../build-support/setup-hooks/make-binary-wrapper.sh} $out --replace " cc " " ${gcc}/bin/cc "
-  '');
+  makeBinaryWrapper = let
+    script = runCommand "make-binary-wrapper.sh" {} ''
+      substitute ${../build-support/setup-hooks/make-binary-wrapper.sh} $out \
+        --replace " @CC@ " " ${gcc}/bin/cc "
+    '';
+  in
+    makeSetupHook { deps = [ dieHook ]; } script;
 
   makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:
     callPackage ../build-support/kernel/modules-closure.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
